### PR TITLE
chore: Add developer advocates to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *     @aws-amplify/amplify-support-eng @aws-amplify/amplify-ui
+/public/learn/images/ @aws-amplify/developer-advocates @aws-amplify/amplify-support-eng


### PR DESCRIPTION
Add @aws-amplify/developer-advocates as owners of /public/learn/images tree

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
