### PR TITLE
Use 'query' property to interpolate dynamic routes

### DIFF
--- a/src/components/CardLayout/CardLayout.tsx
+++ b/src/components/CardLayout/CardLayout.tsx
@@ -47,11 +47,13 @@ export function CardLayout({
       <Link
         href={{
           pathname: "/courses/[courseurltitle]",
+          query: {
+            courseurltitle: createCourseTitleUri(
+              course.courseUrlTitle,
+              course.id
+            ),
+          },
         }}
-        as={`/courses/${createCourseTitleUri(
-          course.courseUrlTitle,
-          course.id
-        )}`}
       >
         <a style={{ textDecoration: "none" }} className={styles["course-card"]}>
           <Flex gap="24px" direction="column">

--- a/src/components/ContributorCollection/ContributorCollection.tsx
+++ b/src/components/ContributorCollection/ContributorCollection.tsx
@@ -42,8 +42,10 @@ export function ContributorCollection({
           key={item.id}
           href={{
             pathname: "/about/[contributor]",
+            query: {
+              contributor: item.username,
+            },
           }}
-          as={`/about/${item.username}`}
         >
           <a className={styles["contributor-card-hyperlink"]}>
             <Card

--- a/src/components/CourseContributors/CourseContributors.tsx
+++ b/src/components/CourseContributors/CourseContributors.tsx
@@ -25,8 +25,10 @@ export function CourseContributors({
             key={index}
             href={{
               pathname: "/about/[contributor]",
+              query: {
+                contributor: contributor.username,
+              },
             }}
-            as={`/about/${contributor.username}`}
           >
             <a className={styles["course-contributor-hyperlink"]}>
               <ContributorHorizontal

--- a/src/components/LessonTableOfContents/LessonTableOfContents.tsx
+++ b/src/components/LessonTableOfContents/LessonTableOfContents.tsx
@@ -51,20 +51,16 @@ export function LessonTableOfContents({
           ? router.pathname
           : `${router.pathname}/lessons/[lesson]`;
 
-      const asPath =
-        router.asPath.indexOf("lessons") > -1
-          ? `${router.asPath.substring(0, router.asPath.lastIndexOf("/"))}/${
-              lesson.lessonNumber
-            }`
-          : `${router.asPath}/lessons/${lesson.lessonNumber}`;
-
       result.push(
         <View key={`lesson-${lesson.lessonNumber}`} padding="0px 8px">
           <Link
             href={{
               pathname: pathname,
+              query: {
+                courseurltitle: router.query.courseurltitle,
+                lesson: lesson.lessonNumber,
+              },
             }}
-            as={asPath}
           >
             <a style={{ textDecoration: "none" }}>
               <Flex

--- a/src/components/TagButton/TagButton.tsx
+++ b/src/components/TagButton/TagButton.tsx
@@ -23,8 +23,10 @@ export function TagButton({
     <Link
       href={{
         pathname: "/tags/[tagname]",
+        query: {
+          tagname: tag.name,
+        },
       }}
-      as={`/tags/${tag.name}`}
     >
       <a
         target="_blank"

--- a/src/pages/courses/[courseurltitle]/index.tsx
+++ b/src/pages/courses/[courseurltitle]/index.tsx
@@ -81,8 +81,11 @@ export default function CoursePage(data: {
         <Link
           href={{
             pathname: `${router.pathname}/lessons/[lesson]`,
+            query: {
+              courseurltitle: router.query.courseurltitle,
+              lesson: "1",
+            },
           }}
-          as={`${router.asPath}/lessons/1`}
         >
           <a className="link-button">
             <View

--- a/src/ui-components/HeroLayoutCustom.jsx
+++ b/src/ui-components/HeroLayoutCustom.jsx
@@ -245,11 +245,13 @@ export default function HeroLayout(props) {
           <Link
             href={{
               pathname: "/courses/[courseurltitle]",
+              query: {
+                courseurltitle: createCourseTitleUri(
+                  course.courseUrlTitle,
+                  course.id
+                ),
+              },
             }}
-            as={`/courses/${createCourseTitleUri(
-              course.courseUrlTitle,
-              course.id
-            )}`}
           >
             <a className="link-button">
               <View


### PR DESCRIPTION
*Issue #, if available:*
- When visiting the learn site with query params in the URL, client side navigation was appending paths after the query params, creating links that did not exist.

*Description of changes:*
- Switch from using the `as` property in the next.js `<Link>` component to use `query` instead

*To test*:
1. Visit staging url
2. Add a query param at the end of the URL, like `?test=12345`, and hit enter to make it reload the page
3. Verify that the "Start course" button correctly navigates to the first lesson
4. Repeat steps 1-2 and verify that the table of contents works as well

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
